### PR TITLE
Implementa detecção automática da impressora no Linux/CUPS com fallba…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+# Resumo
+
+Este PR melhora a experiência no Linux ao reduzir configuração manual de impressora.
+
+# O que foi alterado
+
+- Seleção automática da impressora no backend com fallback.
+- Suporte à impressora padrão do CUPS (Ubuntu/Linux).
+- Retorno de `defaultPrinter` no endpoint `GET /printers`.
+- Tratamento de payload sem `printerConfig` completo.
+- Documentação atualizada no `README`.
+
+# Ordem de resolução da impressora
+
+1. Impressora enviada no payload (se existir no sistema).
+2. `PRINTER_NAME` (variável de ambiente, opcional).
+3. Impressora padrão via `node-printer`.
+4. Impressora padrão via CUPS (`lpstat -d` / `lpoptions -d`).
+5. Primeira impressora disponível.
+
+# Motivação
+
+No Linux, muitos usuários já têm impressora térmica configurada no CUPS, mas não sabem coletar manualmente nome/caminho/fabricante para o payload. Este PR simplifica a instalação e reduz erros de configuração.
+
+# Como validar
+
+1. Configurar impressora padrão no sistema:
+   - `lpstat -p -d`
+   - `lpoptions -d NOME_DA_IMPRESSORA`
+2. Subir o servidor: `node server.js`
+3. Consultar `GET /printers` e conferir `defaultPrinter`.
+4. Enviar `POST /print` sem `printerConfig` completo e validar impressão.
+
+# Compatibilidade
+
+- Mantém compatibilidade com payload antigo (quando `printerConfig` é enviado).
+- Adiciona comportamento automático para cenários incompletos.
+
+# Checklist
+
+- [ ] Código testado localmente no Linux/CUPS
+- [ ] Fluxo com payload completo continua funcionando
+- [ ] Fluxo com payload incompleto funciona com impressora padrão
+- [ ] README atualizado

--- a/README.md
+++ b/README.md
@@ -77,6 +77,35 @@ npm install
 node server.js
 ```
 
+## Impressora automática (Linux/CUPS)
+
+Agora o servidor tenta selecionar a impressora automaticamente para reduzir configuração manual.
+
+Ordem de resolução no `POST /print`:
+
+1. Usa a impressora enviada no payload (se existir no sistema).
+2. Usa a impressora padrão do sistema (CUPS).
+3. Usa a primeira impressora disponível na lista.
+
+Também foi adicionado o campo `defaultPrinter` no endpoint `GET /printers`.
+
+### Forçar uma impressora (opcional)
+
+Se você quiser fixar uma impressora sem alterar código, pode iniciar o servidor com:
+
+```shell
+PRINTER_NAME="NOME_DA_IMPRESSORA" node server.js
+```
+
+### Definir impressora padrão no Ubuntu (CUPS)
+
+```shell
+lpstat -p -d
+lpoptions -d NOME_DA_IMPRESSORA
+```
+
+Assim o sistema usa automaticamente a impressora padrão do seu Linux para impressão dos pedidos.
+
 # Este projeto ajudou você?
 
 Se esse projeto deixar você ficar à vontade para fazer uma doação =), pode ser R $ 0,50 hahahaha. Para isso, basta ler o qrcode abaixo, ele foi gerado com meu outro projeto chamado [Pypix](https://github.com/cleitonleonel/pypix.git) arquivo de amostra.

--- a/controllers/printerController.js
+++ b/controllers/printerController.js
@@ -1,14 +1,112 @@
 const printer_constants = require("./printerConstants");
 const node_printer = require("@thiagoelg/node-printer");
 const unidecode = require("unidecode");
+const { execSync } = require("child_process");
 const PRINTER_STATUS = {
   ERROR_PRINTER_NOT_CONFIGURED: "ERROR_PRINTER_NOT_CONFIGURED",
   ERROR_PRINTER_UNAVAILABLE: "ERROR_PRINTER_UNAVAILABLE",
   PRINTER_OK: "PRINTER_OK"
 };
+// Fabricante padrão para manter compatibilidade quando o payload não informa marca.
+const DEFAULT_MANUFACTURER = "Epson";
+
 function getPrinterList() {
-  return node_printer.getPrinters().map((printerObj) => printerObj.name);
+  try {
+    return node_printer.getPrinters().map((printerObj) => printerObj.name);
+  } catch (error) {
+    return [];
+  }
 }
+
+function getDefaultPrinterByNodePrinter() {
+  // Usa API nativa da lib, quando disponível.
+  if (typeof node_printer.getDefaultPrinterName === "function") {
+    try {
+      return node_printer.getDefaultPrinterName();
+    } catch (error) {
+      return null;
+    }
+  }
+  return null;
+}
+
+function getDefaultPrinterByCups() {
+  // Fallback Linux/CUPS: tenta descobrir a impressora padrão via lpstat.
+  try {
+    const output = execSync("lpstat -d", { encoding: "utf8" }).trim();
+    const match = output.match(/system default destination:\s*(.+)$/i);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  } catch (error) {
+  }
+
+  // Segundo fallback CUPS: lê o destino padrão salvo em lpoptions.
+  try {
+    const output = execSync("lpoptions -d", { encoding: "utf8" }).trim();
+    const match = output.match(/dest\s+(.+)$/i);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  } catch (error) {
+  }
+
+  return null;
+}
+
+function getDefaultPrinterName(availablePrinters) {
+  const printers = availablePrinters || getPrinterList();
+  // Permite override opcional por variável de ambiente sem mexer no código.
+  const envPrinter = process.env.PRINTER_NAME;
+  if (envPrinter && printers.includes(envPrinter)) {
+    return envPrinter;
+  }
+
+  // Ordem de resolução automática: env -> node-printer -> CUPS -> primeira disponível.
+  const nodeDefaultPrinter = getDefaultPrinterByNodePrinter();
+  if (nodeDefaultPrinter && printers.includes(nodeDefaultPrinter)) {
+    return nodeDefaultPrinter;
+  }
+
+  const cupsDefaultPrinter = getDefaultPrinterByCups();
+  if (cupsDefaultPrinter && printers.includes(cupsDefaultPrinter)) {
+    return cupsDefaultPrinter;
+  }
+
+  return printers.length ? printers[0] : null;
+}
+
+function resolvePrinterName(requestedPrinterName) {
+  const printers = getPrinterList();
+  // Respeita o nome enviado pelo cliente apenas se existir no sistema.
+  if (requestedPrinterName && printers.includes(requestedPrinterName)) {
+    return requestedPrinterName;
+  }
+
+  return getDefaultPrinterName(printers);
+}
+
+function inferManufacturerByName(printerName) {
+  if (!printerName) {
+    return DEFAULT_MANUFACTURER;
+  }
+
+  const normalizedName = printerName.toLowerCase();
+  const knownManufacturers = Object.keys(printer_constants);
+  const matchedManufacturer = knownManufacturers.find((manufacturer) => normalizedName.includes(manufacturer.toLowerCase()));
+
+  return matchedManufacturer || DEFAULT_MANUFACTURER;
+}
+
+function resolvePrinterManufacturer(requestedManufacturer, printerName) {
+  // Mantém fabricante enviado quando é suportado pelo mapa de comandos ESC/POS.
+  if (requestedManufacturer && printer_constants[requestedManufacturer]) {
+    return requestedManufacturer;
+  }
+
+  return inferManufacturerByName(printerName);
+}
+
 function getPrinterStatus(printerName, printerManufacturer) {
   if (!printerName || !printerManufacturer) {
     console.error("Printer not configured");
@@ -70,4 +168,10 @@ function print(printables, printerName, printerManufacturer) {
   });
 }
 
-module.exports = {getPrinterList, print}
+module.exports = {
+  getPrinterList,
+  getDefaultPrinterName,
+  resolvePrinterName,
+  resolvePrinterManufacturer,
+  print
+}

--- a/routes/printerRoutes.js
+++ b/routes/printerRoutes.js
@@ -22,12 +22,15 @@ router.get("/", (_, res) => {
 router.get("/printers", (_, res) => {
   try {
     let printers = Printer.getPrinterList();
+    // Exibe no endpoint a impressora padrão efetiva para facilitar diagnóstico.
+    let defaultPrinter = Printer.getDefaultPrinterName(printers);
     if (printers.length < 1) {
       printers = [
         "Printer Test - Server Node",
       ];
+      defaultPrinter = null;
     }
-    res.json({printers, version});
+    res.json({printers, defaultPrinter, version});
   } catch (error) {
     res.status(500);
     res.json({
@@ -38,8 +41,32 @@ router.get("/printers", (_, res) => {
 });
 
 router.post("/print", async (req, res) => {
-  const {invoice, printerConfig: {printerManufacturer, printer}} = req.body;
+  const invoice = req.body && req.body.invoice;
+  const printerConfig = req.body && req.body.printerConfig ? req.body.printerConfig : {};
+  // Se o payload vier sem impressora, resolve automaticamente com base no sistema.
+  const printer = Printer.resolvePrinterName(printerConfig.printer);
+  // Se a marca não vier (ou vier inválida), tenta inferir pelo nome e usa fallback.
+  const printerManufacturer = Printer.resolvePrinterManufacturer(printerConfig.printerManufacturer, printer);
   console.log(printerManufacturer, printer);
+
+  if (!invoice) {
+    res.status(400);
+    res.send({
+      message: "Invalid print payload.",
+      version
+    });
+    return;
+  }
+
+  if (!printer) {
+    res.status(500);
+    res.send({
+      message: "No printers available in the operating system.",
+      version
+    });
+    return;
+  }
+
   if (printer === "PDF") {
     let bufferData = Buffer.from(invoice);
     let dataString = bufferData.toString();
@@ -62,7 +89,7 @@ router.post("/print", async (req, res) => {
         payload: invoice
       }], printer, printerManufacturer);
       console.log("Successfully printed");
-      res.send({message: "Successfully printed", jobId, version});
+      res.send({message: "Successfully printed", jobId, printer, printerManufacturer, version});
     } catch (error) {
       console.log("For unknown reason it was not possible to print.");
       res.status(500);


### PR DESCRIPTION
**Resumo**
Este PR melhora a experiência de impressão no Linux (Ubuntu/CUPS), removendo a necessidade de configuração manual obrigatória da impressora no payload.

**Problema**
No fluxo atual, quando o painel web do iFood envia o teste de impressão, o servidor depende de dados manuais da impressora (printer e printerManufacturer).
Na prática, muitos usuários Linux já têm a impressora térmica configurada no CUPS, mas não sabem coletar e informar esses dados corretamente.

**Solução implementada**
Foi adicionada resolução automática da impressora no backend, com ordem de fallback:

Usa a impressora enviada no payload (se existir no sistema)
Usa PRINTER_NAME (variável de ambiente, opcional)
Usa a impressora padrão retornada pela lib de impressão
Usa a impressora padrão do CUPS (lpstat -d / lpoptions -d)
Usa a primeira impressora disponível no sistema
Também foi adicionado fallback automático de fabricante, com inferência pelo nome da impressora e fabricante padrão para manter compatibilidade.

**Melhorias de API**
GET /printers agora também retorna defaultPrinter
POST /print ficou resiliente para payload sem printerConfig completo
Respostas de erro ficaram mais claras para cenários sem impressora disponível ou payload inválido
Compatibilidade
Mantém compatibilidade com o comportamento anterior (quando printerConfig é enviado completo)
Adiciona comportamento automático para facilitar o uso por usuários Linux menos técnicos

**Como validar**
Configurar impressora padrão no Linux/CUPS
Iniciar o servidor
Chamar GET /printers e validar defaultPrinter
Enviar POST /print sem printerConfig completo
Confirmar impressão na impressora padrão do sistema
Impacto esperado
Redução de falhas de configuração manual, onboarding mais simples e maior adoção do projeto por usuários de Linux que usam o Gestor de Pedidos na versão web.

